### PR TITLE
feature: added support for plugins to listen and generate content at the request-listener level

### DIFF
--- a/cooker/bin/commands/start/request-listener.js
+++ b/cooker/bin/commands/start/request-listener.js
@@ -214,6 +214,8 @@ async function requestListener(req, res) {
   const isStatic = ext && !Object.keys(extMap).includes(ext);
   let file;
 
+  
+
   logger.announce(["Resolving", pathname]);
 
   const contentType = mime.lookup(pathname);
@@ -240,6 +242,21 @@ async function requestListener(req, res) {
     } catch (err) {
       _error(res, file, err);
       return;
+    }
+  }
+
+  if(config.OPTIONS.plugins) {
+    for (let i = 0; i < config.OPTIONS.plugins.length; i++) {
+      const plugin = config.OPTIONS.plugins[i];
+      
+      if(plugin.endPoint && typeof plugin.endPoint === 'function') {
+        const pluginResult = plugin.endPoint(req.url);
+        if(pluginResult && pluginResult.body) {
+          const contents = pluginResult.type === 'html' ? plugSocketIO(pluginResult.body) : pluginResult.body
+          _respond(res, { contentType: `text/${pluginResult.type}`, contents });
+          return;
+        }
+      }
     }
   }
 

--- a/cooker/bin/commands/start/request-listener.js
+++ b/cooker/bin/commands/start/request-listener.js
@@ -223,6 +223,22 @@ async function requestListener(req, res) {
     contentType,
   };
 
+
+  if(config.OPTIONS.plugins) {
+    for (let i = 0; i < config.OPTIONS.plugins.length; i++) {
+      const plugin = config.OPTIONS.plugins[i];
+      
+      if(plugin.endPoint && typeof plugin.endPoint === 'function') {
+        const pluginResult = plugin.endPoint(req.url);
+        if(pluginResult && pluginResult.body) {
+          const contents = pluginResult.type === 'html' ? plugSocketIO(pluginResult.body) : pluginResult.body
+          _respond(res, { contentType: `text/${pluginResult.type}`, contents });
+          return;
+        }
+      }
+    }
+  }
+
   // if file is static we just serve the contents
   // NOTE: this should very rarely happen as express takes care
   // of static files.
@@ -245,20 +261,6 @@ async function requestListener(req, res) {
     }
   }
 
-  if(config.OPTIONS.plugins) {
-    for (let i = 0; i < config.OPTIONS.plugins.length; i++) {
-      const plugin = config.OPTIONS.plugins[i];
-      
-      if(plugin.endPoint && typeof plugin.endPoint === 'function') {
-        const pluginResult = plugin.endPoint(req.url);
-        if(pluginResult && pluginResult.body) {
-          const contents = pluginResult.type === 'html' ? plugSocketIO(pluginResult.body) : pluginResult.body
-          _respond(res, { contentType: `text/${pluginResult.type}`, contents });
-          return;
-        }
-      }
-    }
-  }
 
   let contents;
   switch (ext) {

--- a/cooker/bin/commands/start/request-listener.js
+++ b/cooker/bin/commands/start/request-listener.js
@@ -231,8 +231,8 @@ async function requestListener(req, res) {
       if(plugin.endPoint && typeof plugin.endPoint === 'function') {
         const pluginResult = plugin.endPoint(req.url);
         if(pluginResult && pluginResult.body) {
-          const contents = pluginResult.type === 'html' ? plugSocketIO(pluginResult.body) : pluginResult.body
-          _respond(res, { contentType: `text/${pluginResult.type}`, contents });
+          const contents = pluginResult.type === 'text/html' ? plugSocketIO(pluginResult.body) : pluginResult.body
+          _respond(res, { contentType: pluginResult.type, contents });
           return;
         }
       }

--- a/utensils/lib/config.js
+++ b/utensils/lib/config.js
@@ -32,6 +32,7 @@ let CONFIG = {
     },
   },
   breakpoints: false,
+  plugins: []
 };
 
 if (fse.pathExistsSync(CONFIG_PATH)) {


### PR DESCRIPTION
This is the first part of a bigger picture plugin system. For now this only allows plugins to listen and return content at the request-listener. 

It's undocumented for now so we can test on a few projects. 

We can register plugins in sweet-potato.config.js 

```
plugins: [ MyPlugin ]
```

The plugin will need to have a `endPoint` function that takes the req.url string and returns either an object with a type [string] and body [string] or null:

```
const MyPlugin = {
  endPoint: (url) => {
    if(url === '/test/') return { type: 'html', body: '<h1>Hi there</h1>' };
    
    return null;
  }
}
```