### PR TITLE
Add LOCALE_SLUG property to template globals

### DIFF
--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -81,6 +81,7 @@ function npmResolverPlugin() {
 async function saveHtml(outputOptions, { source }) {
   const { destination, filepath, filename, pugFunction, data, locale } =
     outputOptions;
+
   // page dest
   const dest = path.join(destination, filepath);
 
@@ -95,6 +96,7 @@ async function saveHtml(outputOptions, { source }) {
     RELATIVE_ROOT: relroot ? relroot : ".",
     BREAKPOINTS: config.OPTIONS.breakpoints || {},
     PAGE_SLUG: slug,
+    LOCALE_SLUG: locale,
     ...data.globals,
   };
 


### PR DESCRIPTION
Resolves: https://wethecollective.teamwork.com/#/tasks/19505508

This update adds the name of the template data file to the `globals` which get passed to the Pug compiler.

## Some good use-cases for this:

### Localizing meta URLS
```pug
meta(
  property="og:url"
  content=`${globals.PUBLIC_URL}/${globals.LOCALE_SLUG}`
)
```

### Pointing to localized assets
```pug
img(src=`${globals.RELATIVE_ROOT}/assets/images/${globals.LOCALE_SLUG}/my-localized-image.jpg`)
```