### PR TITLE
Fix/frontend build data

### DIFF
--- a/cooker/lib/javascripts.js
+++ b/cooker/lib/javascripts.js
@@ -46,7 +46,7 @@ async function javascripts(file) {
     const fileInfo = path.parse(file);
 
     // Continue if we're working in a data folder
-    if (fileInfo.dir.split("/").pop() === 'data') continue;
+    if (fileInfo.dir.split("/").pop() === '_data') continue;
 
     // build dest path
     const DEST = path.join(

--- a/cooker/lib/javascripts.js
+++ b/cooker/lib/javascripts.js
@@ -45,6 +45,9 @@ async function javascripts(file) {
   for (let file of jsFiles) {
     const fileInfo = path.parse(file);
 
+    // Continue if we're working in a data folder
+    if (fileInfo.dir.split("/").pop() === 'data') continue;
+
     // build dest path
     const DEST = path.join(
       config.BUILD_DIRECTORY,

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -445,8 +445,8 @@ async function pages(file, localeFile) {
 
     // Get data from a model, if available
     const model = await getDataFromDataInclude(
-      path.join(templateInfo.dir, "data", "index.js"),
-      path.join(templateInfo.dir, "data")
+      path.join(templateInfo.dir, "_data", "index.js"),
+      path.join(templateInfo.dir, "_data")
     );
 
     // Get any included page functions

--- a/cooker/package.json
+++ b/cooker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/sweet-potato-cooker",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Opinionated and minimal static website generator",
   "main": "bin/index.js",
   "bin": {

--- a/cooker/package.json
+++ b/cooker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/sweet-potato-cooker",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Opinionated and minimal static website generator",
   "main": "bin/index.js",
   "bin": {

--- a/documentation/pages/model.md
+++ b/documentation/pages/model.md
@@ -16,7 +16,7 @@ The model itself is just a node js file that's consumed at compile time. This fi
 
 ## Usage
 
-To compile data for this object you would create a data folder relative to the page you wanted to apply it to. For example if you wanted to compile some news data, your folder structure might look like this:
+To compile data for this object you would create a `_data` folder relative to the page you wanted to apply it to. For example if you wanted to compile some news data, your folder structure might look like this:
 
 ```
 pages/
@@ -24,7 +24,7 @@ pages/
   |-- about/
       |-- index.pug
   |-- news/
-      |-- data/
+      |-- _data/
           |-- index.js
       |-- index.pug
 ```
@@ -38,11 +38,11 @@ Given the following folder structure:
 ```
 pages/
   |-- index.pug
-  |-- data/
+  |-- _data/
       |-- index.js
 ```
 
-The contents of data/index.js:
+The contents of _data/index.js:
 
 ```
 module.exports = async function () {
@@ -76,7 +76,7 @@ Given the following folder structure:
 ```
 pages/
   |-- index.pug
-  |-- data/
+  |-- _data/
       |-- index.js
       |-- data.yaml
       |-- events.yaml


### PR DESCRIPTION
This fixes an issue where build would complain about JS files found in `_data` folders and updates the folder that the data function looks for to `_data`. This basically turns the word `_data` into a reserved word for the purposes of JS compilation, hence the need to update it to the implied syntax for uncompiled files.