### PR TITLE
Feature/md matter locale

### DIFF
--- a/cooker/bin/commands/start/request-listener.js
+++ b/cooker/bin/commands/start/request-listener.js
@@ -337,17 +337,6 @@ async function requestListener(req, res) {
         // try the global locale for the page
         const defaultLocalesObj = await resolveLocales(pagePath, config.OPTIONS.locales.defaultName);
         locales = defaultLocalesObj.locales;
-        // LIAM 2021-08-14 - I'm commenting this out because I want to review it later on.
-        // It includes this `potentialLocale` variable that I don't quire understand right now, just refactoring.
-        // const locale = path.resolve(
-        //   config.PAGES_DIRECTORY,
-        //   potentialLocale,
-        //   pagePath.join("/"),
-        //   config.OPTIONS.locales.directoryName,
-        //   config.OPTIONS.locales.defaultName + ".yaml"
-        // );
-        // if (!fse.pathExistsSync(locale)) locales = null;
-        // else locales = [locale];
         
         if (!defaultLocalesObj.exists) locales = null;
       }
@@ -390,10 +379,6 @@ async function resolveLocales(pagePath, n, additionalComponents = []) {
     path.join(pageLocalePath, `${n}.yaml`),
     path.join(pageLocalePath, `${n}.md`),
   ].filter((l) => fse.pathExistsSync(l));
-  
-  // const exists = locales.reduce((a, c) => {
-  //   return a !== false || fse.pathExistsSync(c) !== false;
-  // }, false);
 
   const exists = locales.length > 0;
 

--- a/cooker/bin/commands/start/request-listener.js
+++ b/cooker/bin/commands/start/request-listener.js
@@ -389,11 +389,13 @@ async function resolveLocales(pagePath, n, additionalComponents = []) {
   let locales = [
     path.join(pageLocalePath, `${n}.yaml`),
     path.join(pageLocalePath, `${n}.md`),
-  ];
+  ].filter((l) => fse.pathExistsSync(l));
   
-  const exists = locales.reduce((a, c) => {
-    return a !== false || fse.pathExistsSync(c) !== false;
-  }, false);
+  // const exists = locales.reduce((a, c) => {
+  //   return a !== false || fse.pathExistsSync(c) !== false;
+  // }, false);
+
+  const exists = locales.length > 0;
 
   return {
     pageLocalePath,

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -188,7 +188,7 @@ async function getDataFromMarkdown(file) {
   try {
     const mdfile = matter.read(file);
     result = Object.assign({}, mdfile.data, {
-      content: Markdown.render(mdfile.content),
+      markdownContent: Markdown.render(mdfile.content),
     });
   } catch (error) {
     logger.error(

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -334,7 +334,7 @@ async function assemblePageOptions(
     })
   } else
     localeFiles = await getFiles(
-      path.join(templateInfo.dir, "locales", "*.yaml|*.md")
+      path.join(templateInfo.dir, "locales", "?(*.yaml|*.md)")
     );
 
   // TO DO NEED TO ADD A WAY IN HERE TO COMBINE LOCALE FILES WHEN THEY MATCH
@@ -427,7 +427,7 @@ async function pages(file, localeFiles) {
   if (
     (file &&
       (!fse.pathExistsSync(file) || !file.includes(config.PAGES_DIRECTORY))) ||
-    (localeFiles[0] && !fse.pathExistsSync(localeFiles[0]))
+    (localeFiles && localeFiles[0] && !fse.pathExistsSync(localeFiles[0]))
   )
     return;
 

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -188,7 +188,8 @@ async function getDataFromMarkdown(file) {
   try {
     const mdfile = matter.read(file);
     result = Object.assign({}, mdfile.data, {
-      markdownContent: Markdown.render(mdfile.content),
+      [config.OPTIONS.locales.markdownVariableName || 'markdownContent']:
+        Markdown.render(mdfile.content),
     });
   } catch (error) {
     logger.error(
@@ -304,8 +305,6 @@ async function getDataFromLocaleFiles(localeFiles) {
 
     dataReturn = Object.assign({}, dataReturn, data);
   };
-
-  console.log(dataReturn);
 
   return dataReturn;
 }

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -291,16 +291,17 @@ async function getDataFromLocaleFiles(localeFiles) {
   // Currently there's no explicit order to this data, should we assume one? Question for later
   for(const file of localeFiles) {
     const localeInfo = path.parse(file);
-    let [, localeID, ext] = localeInfo.base.match(/^(.*)(\.md|\.yaml)/);
 
     let data = {};
 
-    if(ext === '.yaml') {
+    if (localeInfo.ext === ".yaml") {
       data = await getDataFromYaml(file);
-    } else if(ext === '.md') {
+    } else if (localeInfo.ext === ".md") {
       data = await getDataFromMarkdown(file);
     } else {
-      logger.warning([`${ext} not supported? How the hell did we get here?`]);
+      logger.warning([
+        `${localeInfo.ext} not supported? How the hell did we get here?`,
+      ]);
     }
 
     dataReturn = Object.assign({}, dataReturn, data);
@@ -332,6 +333,8 @@ async function assemblePageOptions(
       // something to discuss, should we skip files without master locales?
       if (fse.pathExistsSync(masterLocale)) localeFiles.push(masterLocale);
     })
+
+
   } else
     localeFiles = await getFiles(
       path.join(templateInfo.dir, "locales", "?(*.yaml|*.md)")

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -337,9 +337,9 @@ async function assemblePageOptions(
       path.join(templateInfo.dir, "locales", "?(*.yaml|*.md)")
     );
 
-  // TO DO NEED TO ADD A WAY IN HERE TO COMBINE LOCALE FILES WHEN THEY MATCH
+  // Combine different types of localefiles into common locale objects based on their name
+  // For example if both default.yaml and default.md exist, these will be combined for processing.
   const locales = {};
-
   localeFiles.forEach(file => {
     const fileInfo = path.parse(file);
     locales[fileInfo.name] = locales[fileInfo.name] || [];

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -305,6 +305,8 @@ async function getDataFromLocaleFiles(localeFiles) {
     dataReturn = Object.assign({}, dataReturn, data);
   };
 
+  console.log(dataReturn);
+
   return dataReturn;
 }
 

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -8,7 +8,10 @@ const path = require("path");
 const resolve = require("resolve");
 const matter = require("gray-matter");
 const Markdown = require("markdown-it")({ html: true });
+const markdownItAttrs = require("markdown-it-attrs");
 const { config, logger, getFiles } = require("@wethegit/sweet-potato-utensils");
+
+Markdown.use(markdownItAttrs, {});
 
 // local imports
 const { getClientEnvironment } = require("./env.js");

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -146,6 +146,8 @@ async function saveHtml(outputOptions, { source }) {
   }
 }
 
+
+
 /**
  * getDataFromYaml
  * Reads a yaml file and returns the compiled data
@@ -162,7 +164,7 @@ async function getDataFromYaml(file) {
     result = yaml.load(content);
   } catch (error) {
     logger.error(
-      [`Can't compile global yaml`, path.relative(config.CWD, file)],
+      [`Can't compile yaml`, path.relative(config.CWD, file)],
       error
     );
 
@@ -170,6 +172,35 @@ async function getDataFromYaml(file) {
   }
 
   return result;
+}
+
+/**
+ * Retrieves locale data from a matter-styled markdown file and renderes the markdown to HTML.
+ * 
+ * @typedef {Object} getDataFromMarkdown
+ * @property {string} file - The full path to the markdown file. Will read with matter and then render the contained markdown
+ */
+async function getDataFromMarkdown(file) {
+  let result = {};
+
+  if (!fse.pathExistsSync(file)) return result;
+
+  try {
+    const mdfile = matter.read(file);
+    result = Object.assign({}, mdfile.data, {
+      content: Markdown.render(mdfile.content),
+    });
+  } catch (error) {
+    logger.error(
+      [`Can't compile markdown`, path.relative(config.CWD, file)],
+      error
+    );
+
+    throw error;
+  }
+
+  return result;
+
 }
 
 /**
@@ -200,13 +231,6 @@ async function getDataFromDataInclude(file, filepath) {
 
   return result;
 }
-
-/**
- * @typedef {Object} ParsedMarkdown
- * @property {Object} templateInfo - An object containing the combined data for the markdown's rendering template. Result of path.parse(template) with the name and dir modified to variables supplied by the matter file.
- * @property {string} file - The full path to the template pug file. This will replace the parsed file for rendering
- * @property {Object} mdData - The markdown data for rendition.
- */
 
 /**
  * Parses a markdown file from a path, file, and templateInfo supplied by the pages function.
@@ -256,6 +280,35 @@ function parseMarkdown(file, fileInfo) {
 }
 
 /**
+ * Serves as a wrapper around various data resolution methods. Takes a fileInfo and returns an object that contains all of the variables contained within.
+ * 
+ * @param {Array} localeFiles - An array of locale files for consumption
+ */
+async function getDataFromLocaleFiles(localeFiles) {
+  let dataReturn = {}
+
+  // Currently there's no explicit order to this data, should we assume one? Question for later
+  for(const file of localeFiles) {
+    const localeInfo = path.parse(file);
+    let [, localeID, ext] = localeInfo.base.match(/^(.*)(\.md|\.yaml)/);
+
+    let data = {};
+
+    if(ext === '.yaml') {
+      data = await getDataFromYaml(file);
+    } else if(ext === '.md') {
+      data = await getDataFromMarkdown(file);
+    } else {
+      logger.warning([`${ext} not supported? How the hell did we get here?`]);
+    }
+
+    dataReturn = Object.assign({}, dataReturn, data);
+  };
+
+  return dataReturn;
+}
+
+/**
  * Assembles all of the page options into an array for processing.
  *
  * @param {templateInfo} templateInfo - An object containing the combined data for the rendering template.
@@ -269,17 +322,30 @@ async function assemblePageOptions(
   outputOptions
 ) {
   // Find locale files based on main updated file, if it exists
-  let localeFiles;
+  let localeFiles = [];
   const outputData = [];
   if (singleLocale) {
-    const masterLocale = path.join(templateInfo.dir, "locales", singleLocale);
+    singleLocale.forEach((localeFile) => {
+      const masterLocale = path.join(templateInfo.dir, "locales", localeFile);
 
-    // something to discuss, should we skip files without master locales?
-    if (fse.pathExistsSync(masterLocale)) localeFiles = [masterLocale];
+      // something to discuss, should we skip files without master locales?
+      if (fse.pathExistsSync(masterLocale)) localeFiles.push(masterLocale);
+    })
   } else
     localeFiles = await getFiles(
-      path.join(templateInfo.dir, "locales", "*.yaml")
+      path.join(templateInfo.dir, "locales", "*.yaml|*.md")
     );
+
+  // TO DO NEED TO ADD A WAY IN HERE TO COMBINE LOCALE FILES WHEN THEY MATCH
+  const locales = {};
+
+  localeFiles.forEach(file => {
+    const fileInfo = path.parse(file);
+    locales[fileInfo.name] = locales[fileInfo.name] || [];
+    locales[fileInfo.name].push(file);
+  });
+
+
 
   // If there are no locale files, we compile the file with the bare bones of information.
   if (localeFiles.length <= 0) {
@@ -301,17 +367,14 @@ async function assemblePageOptions(
 
     // Otherwise we loop through and create a build for each locale
   } else {
-    // go through the locale files
-    for (const locale of localeFiles) {
-      // get the file info
-      const localeInfo = path.parse(locale);
 
-      // get the main locale
+    // Loop through the discovered locales
+    for(const locale in locales) {
+      // get the root locale
       let mainYamlFile = path.join(
         config.GLOBAL_LOCALES_DIRECTORY,
-        localeInfo.base
+        `${locale}.yaml`
       );
-
       // if doesn't exists uses default
       if (!fse.pathExistsSync(mainYamlFile))
         mainYamlFile = path.join(
@@ -321,19 +384,20 @@ async function assemblePageOptions(
 
       let mainYaml = await getDataFromYaml(mainYamlFile);
 
+      const pageLoaleData = await getDataFromLocaleFiles(locales[locale]);
+
       const globals = Object.assign({}, outputOptions.data.globals, mainYaml);
-      const pageYaml = await getDataFromYaml(locale);
-      const page = Object.assign({}, outputOptions.data.page, pageYaml);
+      const page = Object.assign({}, outputOptions.data.page, pageLoaleData);
       const pagePlugins = outputOptions.data.pagePlugins;
 
       // render the html with the data and save it
       const options = {
         ...outputOptions,
-        locale: localeInfo.name,
+        locale,
         destination:
           // default locale doesn't generate a sub directory
-          localeInfo.name !== "default"
-            ? path.join(config.BUILD_DIRECTORY, localeInfo.name)
+          locale !== "default"
+            ? path.join(config.BUILD_DIRECTORY, locale)
             : config.BUILD_DIRECTORY,
         data: {
           ...outputOptions.data,
@@ -358,11 +422,11 @@ async function assemblePageOptions(
  *
  * @returns {promise} - Resolves to array of objects with the page information
  */
-async function pages(file, localeFile) {
+async function pages(file, localeFiles) {
   if (
     (file &&
       (!fse.pathExistsSync(file) || !file.includes(config.PAGES_DIRECTORY))) ||
-    (localeFile && !fse.pathExistsSync(localeFile))
+    (localeFiles[0] && !fse.pathExistsSync(localeFiles[0]))
   )
     return;
 
@@ -372,13 +436,13 @@ async function pages(file, localeFile) {
   if (file) pugFiles = [file];
 
   // Assemble the locale file information
-  if (localeFile) {
-    let fileInfo = path.parse(localeFile);
+  if (localeFiles) {
+    let fileInfo = path.parse(localeFiles[0]);
     // if we have a locale file then we save that specific language
     // that way we only compiled that language template
-    singleLocale = fileInfo.base;
+    singleLocale = localeFiles.map(p => path.parse(p).base); // Map the provided localefiles to their basenames
     // if we are at not at the root then we find the relative template file to the locale file
-    if (!pugFiles && localeFile.includes(config.PAGES_DIRECTORY))
+    if (!pugFiles && localeFiles[0].includes(config.PAGES_DIRECTORY))
       // this assumes that the yaml file lives inside `locales/` just a folder deep
       pugFiles = await getFiles(path.join(fileInfo.dir, "..", "*.pug"));
   }

--- a/cooker/lib/pages.js
+++ b/cooker/lib/pages.js
@@ -7,11 +7,10 @@ const fse = require("fs-extra");
 const path = require("path");
 const resolve = require("resolve");
 const matter = require("gray-matter");
-const Markdown = require("markdown-it")({ html: true });
-const markdownItAttrs = require("markdown-it-attrs");
+const Markdown = require("markdown-it")({ html: true })
+  .use(require("markdown-it-attrs"))
+  .use(require("markdown-it-div"));
 const { config, logger, getFiles } = require("@wethegit/sweet-potato-utensils");
-
-Markdown.use(markdownItAttrs, {});
 
 // local imports
 const { getClientEnvironment } = require("./env.js");

--- a/cooker/package-lock.json
+++ b/cooker/package-lock.json
@@ -2282,6 +2282,11 @@
       "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.0.0.tgz",
       "integrity": "sha512-uLjtdCmhhmL3BuZsReYkFxk74qKjj5ahe34teBpOCJ4hYZZl7/ftLyXWLowngC2moRkbLEvKwN/7TMwbhbHE/A=="
     },
+    "markdown-it-div": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-div/-/markdown-it-div-1.1.0.tgz",
+      "integrity": "sha512-Vz1T8cPG4sRofn5VlwiGMpy7AyhizbBZcFmvVDf/mlDgF7Mt6QqjPhc/nLlLYB3EANkJfO4kym7R6SZ7RhGvCQ=="
+    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",

--- a/cooker/package-lock.json
+++ b/cooker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/sweet-potato-cooker",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -22,6 +22,11 @@
         "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@gerhobbelt/markdown-it-attrs": {
+      "version": "4.0.0-22",
+      "resolved": "https://registry.npmjs.org/@gerhobbelt/markdown-it-attrs/-/markdown-it-attrs-4.0.0-22.tgz",
+      "integrity": "sha512-QanwOF9v790kaFIXBpJetvKIeyX5fdYkpPKs6evrr7xZEdVAAloMCpz6taE7V4bLI5jCc0VeEUpd07n9l1aXmw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -1886,14 +1891,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "image-size": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.0.tgz",
-      "integrity": "sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==",
-      "requires": {
-        "queue": "6.0.2"
-      }
-    },
     "in-publish": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
@@ -2279,6 +2276,11 @@
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       }
+    },
+    "markdown-it-attrs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.0.0.tgz",
+      "integrity": "sha512-uLjtdCmhhmL3BuZsReYkFxk74qKjj5ahe34teBpOCJ4hYZZl7/ftLyXWLowngC2moRkbLEvKwN/7TMwbhbHE/A=="
     },
     "mdurl": {
       "version": "1.0.1",
@@ -3295,14 +3297,6 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-    },
-    "queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "requires": {
-        "inherits": "~2.0.3"
-      }
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/cooker/package.json
+++ b/cooker/package.json
@@ -18,6 +18,7 @@
     "directory": "cooker"
   },
   "dependencies": {
+    "@gerhobbelt/markdown-it-attrs": "^4.0.0-22",
     "@wethegit/sweet-potato-utensils": "^1.0.1",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",
@@ -30,6 +31,7 @@
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.0.0",
     "markdown-it": "^12.1.0",
+    "markdown-it-attrs": "^4.0.0",
     "mime-types": "^2.1.29",
     "node-sass": "^5.0.0",
     "node-sass-asset-functions": "^0.1.0",

--- a/cooker/package.json
+++ b/cooker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/sweet-potato-cooker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Opinionated and minimal static website generator",
   "main": "bin/index.js",
   "bin": {

--- a/cooker/package.json
+++ b/cooker/package.json
@@ -32,6 +32,7 @@
     "js-yaml": "^4.0.0",
     "markdown-it": "^12.1.0",
     "markdown-it-attrs": "^4.0.0",
+    "markdown-it-div": "^1.1.0",
     "mime-types": "^2.1.29",
     "node-sass": "^5.0.0",
     "node-sass-asset-functions": "^0.1.0",

--- a/documentation/pages/config.md
+++ b/documentation/pages/config.md
@@ -51,6 +51,11 @@ Name of the default locale and locale file.
 
 <div id="pagePlugins"></div>
 
+#### locales.markdownVariableName
+
+**Default:** `markdownContent`  
+This is the name of the variable to which markdown content is supplied in the page object.
+
 ### pagePlugins
 
 **Type:** `object`  

--- a/documentation/pages/language.md
+++ b/documentation/pages/language.md
@@ -10,7 +10,7 @@ name: Language and localisation
 
 ### Language
 
-Language is provided to a document via yaml files in the locales folder of each specific page. If you had a website with a homepage and about page in English and French, its structure might look something like this:
+Language is provided to a document via yaml or markdown files in the locales folder of each specific page. If you had a website with a homepage and about page in English and French, its structure might look something like this:
 
 ```
 pages/
@@ -27,8 +27,6 @@ pages/
         └── fr.yml
 
 ```
-
-One important note here is that localised language files _extend_ the default. So if you were to provide a language asset in default and not in en, then the default will be present in en pages.
 
 ### Localisation
 
@@ -138,4 +136,59 @@ You could then access this data from within the `pages/index.pug` file, by doing
 header.main-header
   nav
     h2= globals.main_nav.title
+```
+
+### Supported language files
+
+Currently yaml and markdown files are supported for language files. If more than one language file is present for a specific locale, they'll be concatenated together.
+
+Markdown language files are contructed using matter style layout so they can include a block of variables at the top that extend the object further. Any markdown content rendered will be included in the variable `page.markdownContent`
+
+##### Example
+
+Consider the following structure
+
+```
+src/
+├── locales/
+│   ├── default.yaml
+│   └── default.md
+└── pages/
+    └── index.pug
+```
+
+default.yaml looks like this:
+```yaml
+main_nav:
+  title: Main site navigation
+```
+
+defualt.md looks like this:
+```md
+---
+anchor: maincontent
+---
+
+# This is some markdown content
+- see
+- how
+- it
+- flows
+```
+
+This will generate a language object that looks something like this:
+```
+{
+  main_nav: {
+    title: Main site navigation
+  },
+  anchor: 'maincontent',
+  markdownContent: '<h1>This is some markdown content</h1>\n' +
+    '<ul>\n' +
+    '<li>see</li>\n' +
+    '<li>how</li>\n' +
+    '<li>it</li>\n' +
+    '<li>flows</li>\n' +
+    '</ul>\n'
+}
 ```

--- a/utensils/lib/config.js
+++ b/utensils/lib/config.js
@@ -13,6 +13,7 @@ let CONFIG = {
   locales: {
     directoryName: "locales",
     defaultName: "default",
+    markdownVariableName: "markdownContent",
   },
   sassOptions: () => {
     return {};
@@ -32,7 +33,7 @@ let CONFIG = {
     },
   },
   breakpoints: false,
-  plugins: []
+  plugins: [],
 };
 
 if (fse.pathExistsSync(CONFIG_PATH)) {

--- a/utensils/package.json
+++ b/utensils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/sweet-potato-utensils",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Shared utilities for sweet-potato packages",
   "main": "index.js",
   "engines": {

--- a/utensils/package.json
+++ b/utensils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/sweet-potato-utensils",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Shared utilities for sweet-potato packages",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This updates the sweet potato to allow both yaml and markdown files for locales.

In order to accomplish this I've had to overhaul the way that language determination is handled a bit such that locale files are coalesced into different locales. This ensures that if there is both a yaml and md file present for a specific locale that they are joined into a single page object.

Any markdown data included in the markdown file will be included in a variable called `markdownContent`, the name of this variable is configurable in the SP options file..

### Example

Consider the following structure

```
src/
├── locales/
│   ├── default.yaml
│   └── default.md
└── pages/
    └── index.pug
```

default.yaml looks like this:
```yaml
main_nav:
  title: Main site navigation
```

defualt.md looks like this:
```md
---
anchor: maincontent
---

# This is some markdown content
- see
- how
- it
- flows
```

This will generate a language object that looks something like this:
```
{
  main_nav: {
    title: Main site navigation
  },
  anchor: 'maincontent',
  markdownContent: '<h1>This is some markdown content</h1>\n' +
    '<ul>\n' +
    '<li>see</li>\n' +
    '<li>how</li>\n' +
    '<li>it</li>\n' +
    '<li>flows</li>\n' +
    '</ul>\n'
}
```

![image](https://user-images.githubusercontent.com/627944/129462172-4d884659-5b7b-4e09-aabd-315073e48d71.png)


### Closing

FWIW I would assume that in 99% of cases that a user would use *either* a markdown or a yaml file, not both. But I did want this update to behave somewhat predictably if both were supplied.

I've also tried to approach this update with some future extensibility in mind. That is to say, if we want to add other locale files to the mix in future, this update should allow that quite predictably.