### PR TITLE
Fix/fixing port listen

### DIFF
--- a/cooker/bin/commands/start/index.js
+++ b/cooker/bin/commands/start/index.js
@@ -58,7 +58,7 @@ async function startCommand(options) {
     }
   }
 
-  const createServer = function(host, port, id) {
+  const createServer = function(host, port) {
     const s = http.createServer(app);
     const serverObject = {
       server: s,
@@ -74,19 +74,19 @@ async function startCommand(options) {
   }
 
   // Create our servers and socket instance
-  servers.push(createServer('localhost', 8080, 0));
+  servers.push(createServer("localhost", options.port, 0));
   for (let i in netresults) {
     if (netresults[i].length) {
-      servers.push(createServer(netresults[i][0], 8080, servers.length));
+      servers.push(
+        createServer(netresults[i][0], options.port, servers.length)
+      );
     }
   }
-  // server = http.createServer(app);
 
   const io = require("socket.io")(server);
-  const host = options.host || "localhost";
-  let port = options.port || 8080;
-  let attempts = 0;
+
   const maxAttempts = 3;
+
   const start = () => {
     servers.forEach((server) => {
       server.start();
@@ -111,7 +111,7 @@ async function startCommand(options) {
       // Check if port is already in use
       if (err.code === "EADDRINUSE" && server.attempts <= maxAttempts) {
         logger.announce(
-          `Port ${port} already in use, trying another (attempt ${attempts} of ${maxAttempts}) ...`
+          `Port ${server.port} already in use, trying another (attempt ${server.attempts} of ${maxAttempts}) ...`
         );
         server.port++;
         // try again on another port
@@ -134,7 +134,7 @@ async function startCommand(options) {
     });
   });
 
-  start(port, host);
+  start();
 }
 
 module.exports = startCommand;

--- a/cooker/bin/commands/start/index.js
+++ b/cooker/bin/commands/start/index.js
@@ -74,6 +74,7 @@ async function startCommand(options) {
   let attempts = 0;
   const maxAttempts = 3;
   const start = () => {
+    console.log("starting", attempts)
     attempts++;
     // listen to hits on the host
     servers[0].listen(port, host);
@@ -121,11 +122,8 @@ async function startCommand(options) {
     });
 
     server.on("listening", () => {
-      logger.start(`Server is running on http://${host}:${port}`);
-      for (let i in netresults) {
-        if (netresults[i].length)
-          logger.start(`Also on http://${netresults[i][0]}:${port}`);
-      }
+      const address = server.address();
+      logger.start(`Server is running on http://${address.address}:${address.port}`);
       logger.announce("Watching for changes...");
     });
   });


### PR DESCRIPTION
This fixes a bug where `start` would fail out when a port was in use and there was more than one network adaptor present.